### PR TITLE
Wrong field

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -196,7 +196,7 @@ class provider implements
             $sql = "SELECT p.id
                     FROM {payments} p
                     JOIN {gwpayments} gwp ON p.itemid = gwp.id
-                    WHERE gwp.courseid = :courseid AND p.component = :component";
+                    WHERE gwp.course = :courseid AND p.component = :component";
             $params = [
                 'component' => 'mod_gwpayments',
                 'courseid' => $context->instanceid,


### PR DESCRIPTION
the field courseid does not exist in the table gwpayments:

```
tool_dataprivacy\expired_contexts_test::test_orphaned_records_are_cleared
Unexpected debugging() call detected.
Debugging: Error writing to database (ERROR:  column gwp.courseid does not exist
LINE 4:                     WHERE gwp.courseid = $1 AND p.component ...
                                  ^
HINT:  Perhaps you meant to reference the column "gwp.course".
```
